### PR TITLE
gedis_http: allow the gedis http proxy to listen to both POST and GET verbs

### DIFF
--- a/ThreeBotPackages/threebot/webinterface/bottle/BottleInterfaceFactory.py
+++ b/ThreeBotPackages/threebot/webinterface/bottle/BottleInterfaceFactory.py
@@ -66,7 +66,7 @@ def gedis_websocket(ws):
 #######################################
 ######## GEDIS HTTP ROUTES ############
 #######################################
-@app.route("/gedis/http/<name>/<cmd>", method="post")
+@app.route("/gedis/http/<name>/<cmd>", method=["post", "get"])
 @enable_cors
 def gedis_http(name, cmd):
     client = j.clients.gedis.get(name="main_gedis_threebot", port=8901)


### PR DESCRIPTION
I think this allows more idiomatic usage of HTTP for the client using the gedis_http proxy.
Having to always use POST is very very weird.
The code seems to already handle both case anyway, so I just enable the route for GET too.