### PR TITLE
tfgrid_directory: add a method to farm actor to list farms owned by a certain 3bot id

### DIFF
--- a/ThreeBotPackages/tfgrid/tfgrid_directory/actors/farms.py
+++ b/ThreeBotPackages/tfgrid/tfgrid_directory/actors/farms.py
@@ -52,7 +52,7 @@ class farms(j.baseclasses.threebot_actor):
     def get(self, farm_id, schema_out=None, user_session=None):
         """
         ```in
-        farm_id = (I)
+        farm_id = 0 (I)
         ```
 
         ```out
@@ -80,3 +80,17 @@ class farms(j.baseclasses.threebot_actor):
                 continue
             out.farms.append(farm)
         return out
+
+    def owned_by(self, threebot_id, schema_out=None, user_session=None):
+        """
+        ```in
+        threebot_id = 0 (I)
+        ```
+
+        ```out
+        farms = (LO) !tfgrid.farm.1
+        ```
+        """
+        output = schema_out.new()
+        output.farms = self.farm_model.find(threebot_id=threebot_id)
+        return output

--- a/ThreeBotPackages/tfgrid/tfgrid_directory/models/tfgrid_farmer_1.toml
+++ b/ThreeBotPackages/tfgrid/tfgrid_directory/models/tfgrid_farmer_1.toml
@@ -1,8 +1,0 @@
-#the owner of the farmerss
-
-@url = tfgrid.farmer.1
-owner_threebot_id** = (S)       # not used right now
-iyo_organization** = (S)        # for backward compatibility
-name** = (S)
-wallet_addresses = (LS)
-email = (email)


### PR DESCRIPTION
This method will be used by the farm manager UI. To list all farm owned by a specific 3bot