### PR TITLE
Replace packages in packagemanagerui to packagemanagerui #190

### DIFF
--- a/ThreeBotPackages/zerobot/packagemanagerui/build_frontend.sh
+++ b/ThreeBotPackages/zerobot/packagemanagerui/build_frontend.sh
@@ -1,2 +1,2 @@
 cd packagemanagerui && npm run export
-cp __sapper__/export/packages/* ../frontend/ -R
+cp __sapper__/export/packagemanagerui/* ../frontend/ -R

--- a/ThreeBotPackages/zerobot/packagemanagerui/packagemanagerui/package.json
+++ b/ThreeBotPackages/zerobot/packagemanagerui/packagemanagerui/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "sapper dev",
     "build": "sapper build --legacy",
-    "export": "sapper export --legacy --basepath packages",
+    "export": "sapper export --legacy --basepath packagemanagerui",
     "start": "node __sapper__/build",
     "cy:run": "cypress run",
     "cy:open": "cypress open",

--- a/ThreeBotPackages/zerobot/packagemanagerui/packagemanagerui/src/server.js
+++ b/ThreeBotPackages/zerobot/packagemanagerui/packagemanagerui/src/server.js
@@ -8,7 +8,7 @@ const dev = NODE_ENV === 'development';
 
 polka() // You can also use Express
 	.use(
-		'/packages',
+		'/packagemanagerui',
 		compression({ threshold: 0 }),
 		sirv('static', { dev }),
 		sapper.middleware()


### PR DESCRIPTION
The use of packages resulted in errors in building, therefore replaced them with `packagemanagerui` instead to match the package name.
Issue: #190 