### PR TITLE
Refactore gdrive manager

### DIFF
--- a/ThreeBotPackages/zerobot/webinterface/actors/wiki_gdrive_manager.py
+++ b/ThreeBotPackages/zerobot/webinterface/actors/wiki_gdrive_manager.py
@@ -41,11 +41,6 @@ class wiki_gdrive_manager(j.baseclasses.threebot_actor):
             out.error_message = f"invalid document type of '{doctype}', allowed types are {allowed_types}."
             return out
 
-        if not j.sal.fs.exists(cl.credfile):
-            out.error_code = 400
-            out.error_message = "service credential file is not found"
-            return out
-
         service_name = doctypes_map[doctype]
         try:
             parent_dir = j.sal.fs.joinPaths(STATIC_DIR, doctype)

--- a/ThreeBotPackages/zerobot/webinterface/actors/wiki_gdrive_manager.py
+++ b/ThreeBotPackages/zerobot/webinterface/actors/wiki_gdrive_manager.py
@@ -2,7 +2,7 @@ from Jumpscale import j
 
 try:
     # get gdrive client so google api dependency is installed
-    cl = j.clients.gdrive.get("gdrive_macro_client", credfile=j.core.tools.text_replace("{DIR_BASE}/var/cred.json"))
+    cl = j.clients.gdrive.get("main")
 except:
     pass
 

--- a/docs/wikis/tech/gdrive.md
+++ b/docs/wikis/tech/gdrive.md
@@ -16,8 +16,7 @@ Before setting up needed configuration, you need to [setup a service account for
 1- Configure the main instance of gdrive client and make sure to provide a credentials info with the correct permissions
 
 ```python
-cl = j.clients.gdrive.new(name="main")
-cl.info = json.dumps({json_info_in_cred_file})
+cl = j.clients.gdrive.get_from_file(name="main", path=<path_to_creds_file>)
 cl.save()
 ```
 

--- a/docs/wikis/tech/gdrive.md
+++ b/docs/wikis/tech/gdrive.md
@@ -13,16 +13,14 @@ The current endpoints will get a pdf version of any document, spreadsheets or pr
 ## How to Configure
 Before setting up needed configuration, you need to [setup a service account for google apis](#setting-up-service-account-for-google-apis), then follow the following steps:
 
-1- Configure the main instance of gdrive client and make sure to provide a credentials file with the correct permissions
+1- Configure the main instance of gdrive client and make sure to provide a credentials info with the correct permissions
 
 ```python
-cl = j.clients.gdrive.main
-cl.credfile = "{path_to_cred_file}"
+cl = j.clients.gdrive.new(name="main")
+cl.info = json.dumps({json_info_in_cred_file})
 cl.save()
 ```
 
 ## Setting up service account for google apis
 
 See how to setup a [service account](service_account.md) for different google apis, as it's required by other macros.
-
-


### PR DESCRIPTION
Use the new gdrive client that stores credentials in the schema.

Fixes https://github.com/threefoldtech/jumpscaleX_threebot/issues/339 
depends on https://github.com/threefoldtech/jumpscaleX_libs/pull/53