### PR TITLE
Add city to farm update form in farm management of dashboard

### DIFF
--- a/ThreeBotPackages/threebot/farmmanagement/frontend/views/farmmanagement/farmmanagement.html
+++ b/ThreeBotPackages/threebot/farmmanagement/frontend/views/farmmanagement/farmmanagement.html
@@ -108,6 +108,7 @@
             </v-row> -->
             <v-select v-model="farmToEdit.location.country" menu-props="auto" :items="countries" label="Country">
             </v-select>
+            <v-text-field v-model="farmToEdit.location.city" label="City"></v-text-field>
 
             <v-text-field v-model="farmToEdit.email" label="Email"></v-text-field>
 


### PR DESCRIPTION
The farm update location will include both country and city instead of country only
https://github.com/threefoldtech/jumpscaleX_threebot/issues/680
![Screenshot from 2020-05-21 15-44-08](https://user-images.githubusercontent.com/17128393/82565512-da5c0300-9b7a-11ea-9af4-87aba92f0bbf.png)
